### PR TITLE
Use `StandardPluging.initialize` instead of deprecated `init` method

### DIFF
--- a/plugins/serialversion-remover-plugin/src/main/scala/akka/Plugin.scala
+++ b/plugins/serialversion-remover-plugin/src/main/scala/akka/Plugin.scala
@@ -18,7 +18,7 @@ class SerialVersionRemoverPlugin extends StandardPlugin {
   val name = "serialversion-remover-plugin"
   val description = "Remove SerialVersionUid annotation from traits"
 
-  def init(options: List[String]): List[PluginPhase] = {
+  override def initialize(options: List[String])(using Context): List[PluginPhase] = {
     (new SerialVersionRemoverPhase()) :: Nil
   }
 }


### PR DESCRIPTION
Fixes the community build for the https://github.com/scala/scala3/pull/20330 - adds the override modifier (required) and uses `initialize` instead `init` method (warning supression) 