### PR TITLE
Restore `akka.build.scalaVersion` to provide version of Scala 3 compiler

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,11 @@ object Dependencies {
   val scala213Version = "2.13.7"
   // To get the fix for https://github.com/lampepfl/dotty/issues/13106
   // and restored static forwarders
-  val scala3Version = "3.1.1-RC2"
+  val scala3Version = sys.props.get("akka.build.scalaVersion")
+    .getOrElse {
+      System.err.println("Warning: Using default Scala 3 versions!")
+      "3.1.1-RC3"
+    }
   val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 
   val reactiveStreamsVersion = "1.0.3"


### PR DESCRIPTION
Restore `akka.build.scalaVersion` to provide version of Scala 3 compiler - required for building compiler plugins against the latest compiler API. Previously all the builds of the compiler plugin where done against Scala 3.1.1-RC2 API. 
 
`akka.build.scalaVersion` property is [already set in the CB](https://github.com/scala/scala3/blob/49c13430f6bf8f1c5195f25f4bfb662e6e9dfb51/community-build/src/scala/dotty/communitybuild/projects.scala#L650), but it was never used in the akka code base. 

